### PR TITLE
add_esp32_code

### DIFF
--- a/esp32/fake_keyboard/fake_keyboard.ino
+++ b/esp32/fake_keyboard/fake_keyboard.ino
@@ -1,0 +1,25 @@
+#include <USB.h>
+#include <USBHIDKeyboard.h>
+
+USBHIDKeyboard keyboard;
+
+
+void setup() {
+  Serial.begin(9600);
+  keyboard.begin(KeyboardLayout_fr_FR);
+  USB.begin();
+}
+
+void loop() {
+  if (Serial.available() != 0) {
+    String data = Serial.readStringUntil('\n');
+    
+    Serial.print("recu : ");
+    Serial.println(data);
+
+    keyboard.print(data);
+    keyboard.press(KEY_RETURN);
+    delay(100);
+    keyboard.release(KEY_RETURN);
+  }
+}


### PR DESCRIPTION
Ajout d'un programme pour l'ESP32 qui émule un clavier HID, recevant du texte via le port série et l'envoyant avec un appui sur entrée.